### PR TITLE
Handle suppressed exceptions in ResponseGenerator

### DIFF
--- a/langfair/generator/generator.py
+++ b/langfair/generator/generator.py
@@ -223,7 +223,7 @@ class ResponseGenerator:
         chain = self._setup_langchain(system_prompt=system_prompt)
         tasks, duplicated_prompts = self._create_tasks(chain=chain, prompts=prompts)
         responses = await asyncio.gather(*tasks)
-        non_completion_rate = len([r for r in responses if r == FAILURE_MESSAGE]) / len(
+        non_completion_rate = len([r for r in responses if r == self.failure_message]) / len(
             responses
         )
 

--- a/langfair/generator/generator.py
+++ b/langfair/generator/generator.py
@@ -50,7 +50,11 @@ class ResponseGenerator:
         self.failure_message = FAILURE_MESSAGE
         self.token_cost_date = TOKEN_COST_DATE
         self.llm = langchain_llm
-        self.suppressed_exceptions = suppressed_exceptions
+        if self._valid_exceptions(suppressed_exceptions):
+            self.suppressed_exceptions = suppressed_exceptions
+        else:
+            raise TypeError("suppressed_exceptions must be a subclass of BaseException or a tuple of subclasses of BaseException")
+        
         if max_calls_per_min:
             warnings.warn(
                 "max_calls_per_min is deprecated and will not be used. Use LangChain's `InMemoryRateLimiter` instead",
@@ -279,7 +283,23 @@ class ResponseGenerator:
                 if isinstance(err, self.suppressed_exceptions):
                     return self.failure_message
             raise err
-
+    
+    @staticmethod
+    def _valid_exceptions(exceptions: Union[Tuple[BaseException], BaseException]) -> bool:
+        """Returns true if exceptions is a subclass of BaseException or a tuple of  subclasses of BaseException
+        """
+        if exceptions is None:
+            return True
+        else:
+            try:
+                if isinstance(exceptions, tuple) and all(issubclass(item, BaseException) for item in exceptions):
+                    return True
+                elif issubclass(exceptions, BaseException):
+                    return True
+                else:
+                    return False
+            except:
+                return False
             
     @staticmethod
     def _num_tokens_from_messages(


### PR DESCRIPTION
Changes made:
1. _async_api_call will return self.failure_message when an exception from suppressed_exceptions is raised
2. Otherwise it will raise the exception and stop response generation
3. suppressed exceptions are also validated while constructing the ResponseGenerator object

The check `if isinstance(err, self.suppressed_exceptions)` can handle suppressed_exceptions being a class or tuple of classes natively. `isinstance` can aslo handle subclasses.

**isinstance(object, classinfo)**
Return true if the object argument is an instance of the classinfo argument, or of a (direct, indirect or [virtual](https://docs.python.org/2/glossary.html#term-abstract-base-class)) subclass thereof. Also return true if classinfo is a type object (new-style class) and object is an object of that type or of a (direct, indirect or [virtual](https://docs.python.org/2/glossary.html#term-abstract-base-class)) subclass thereof. If object is not a class instance or an object of the given type, the function always returns false. If classinfo is a tuple of class or type objects (or recursively, other such tuples), return true if object is an instance of any of the classes or types. If classinfo is not a class, type, or tuple of classes, types, and such tuples, a [TypeError](https://docs.python.org/2/library/exceptions.html#exceptions.TypeError) exception is raised.
