### PR TITLE
Fix pyproject and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ pip install langfair
 ```
 
 ### Usage Example
-Below is a sample of code illustrating how to use LangFair's `AutoEval` class for text generation and summarization use cases. The below example assumes the user has already defined parameters `DEPLOYMENT_NAME`, `API_KEY`, `API_BASE`, `API_TYPE`, `API_VERSION`, and a list of prompts from their use case `prompts`.
+Below is a sample of code illustrating how to use LangFair's `AutoEval` class for text generation and summarization use cases. The below example assumes the user has already defined parameters `DEPLOYMENT_NAME`, `API_KEY`, `API_BASE`, `API_TYPE`, `API_VERSION`, and a list of prompts from their use case `prompts`. 
 
-Create `langchain` LLM object.
+Create `langchain` LLM object. Any of LangChain’s LLM classes may be used in place of `AzureChatOpenAI`.
 ```python
 from langchain_openai import AzureChatOpenAI
 # import torch # uncomment if GPU is available

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = ["Dylan Bouchard <dylan.bouchard@cvshealth.com>",
 repository = "https://github.com/cvs-health/langfair"
 homepage = "https://github.com/cvs-health/langfair"
 documentation = "https://cvs-health.github.io/langfair/latest/index.html"
-license = "Apache-2.0, MIT"
+license = "Apache-2.0 AND MIT"
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Operating System :: OS Independent",


### PR DESCRIPTION
This PR does the following:

- fix SPDX expression per [issue #55](https://github.com/cvs-health/langfair/issues/55)
- add language in readme to mention any LangChain llm can be used in place of `AzureChatOpenAI`