### PR TITLE
Fix missing DOIs, `VertexAI` to `ChatVertexAI`, fix spillover

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -145,6 +145,7 @@
       archivePrefix={arXiv},
       primaryClass={cs.CL},
       url={https://arxiv.org/abs/1805.04508}, 
+      doi={10.18653/v1/S18-2005}
 }
 
 
@@ -155,7 +156,8 @@
   author={Samuel Gehman and Suchin Gururangan and Maarten Sap and Yejin Choi and Noah A. Smith},
   booktitle={Findings},
   year={2020},
-  url={https://api.semanticscholar.org/CorpusID:221878771}
+  url={https://api.semanticscholar.org/CorpusID:221878771},
+  doi={10.18653/v1/2020.findings-emnlp.301}
 }
 
 
@@ -406,7 +408,9 @@ year = {2023}
   eprint       = {1907.04135},
   timestamp    = {Wed, 17 Jul 2019 10:27:36 +0200},
   biburl       = {https://dblp.org/rec/journals/corr/abs-1907-04135.bib},
-  bibsource    = {dblp computer science bibliography, https://dblp.org}
+  bibsource    = {dblp computer science bibliography, https://dblp.org},
+  doi          = {
+https://doi.org/10.1109/TVCG.2019.2934619}
 }
 
 
@@ -515,6 +519,7 @@ year = {2023}
       archivePrefix={arXiv},
       primaryClass={cs.CL},
       url={https://arxiv.org/abs/1911.03064}, 
+      doi={10.18653/v1/2020.findings-emnlp.7}
 }
 
 
@@ -541,6 +546,7 @@ year = {2023}
       archivePrefix={arXiv},
       primaryClass={stat.ML},
       url={https://arxiv.org/abs/1412.3756}, 
+      doi={https://doi.org/10.1145/2783258.2783311}
 }
 
 
@@ -552,6 +558,7 @@ year = {2023}
       archivePrefix={arXiv},
       primaryClass={cs.CL},
       url={https://arxiv.org/abs/2012.15859}, 
+      doi={10.18653/v1/2021.acl-long.150}
 }
 
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -46,7 +46,7 @@ Furthermore, LangFair is designed for real-world LLM-based systems that require 
 
 
 # Generation of Evaluation Datasets
-The `langfair.generator` module offers two classes, `ResponseGenerator` and `CounterfactualGenerator`, which aim to enable user-friendly construction of evaluation datasets for text generation use cases.
+The `langfair.generator` module offers two classes, `ResponseGenerator` and `Counterfactual`-`Generator`, which aim to enable user-friendly construction of evaluation datasets for text generation use cases.
 
 
 ### `ResponseGenerator` class

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -46,7 +46,7 @@ Furthermore, LangFair is designed for real-world LLM-based systems that require 
 
 
 # Generation of Evaluation Datasets
-The `langfair.generator` module offers two classes, `ResponseGenerator` and `Counterfactual`-`Generator`, which aim to enable user-friendly construction of evaluation datasets for text generation use cases.
+The `langfair.generator` module offers two classes, `ResponseGenerator` and `Counterfactual`- `Generator`, which aim to enable user-friendly construction of evaluation datasets for text generation use cases.
 
 
 ### `ResponseGenerator` class

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -94,10 +94,10 @@ To streamline assessments for text generation use cases, the `AutoEval` class co
 
 
 ```python
-from langchain_google_vertexai import VertexAI
+from langchain_google_vertexai import ChatVertexAI
 from langfair.auto import AutoEval
 
-llm = VertexAI(model_name='gemini-pro')
+llm = ChatVertexAI(model_name='gemini-pro')
 auto_object = AutoEval(prompts=prompts, langchain_llm=llm)
 results = await auto_object.evaluate()
 ```


### PR DESCRIPTION
Fix missing DOIs, `VertexAI` to `ChatVertexAI`, fix spillover