### PR TITLE
fix capitalization in reference

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -570,7 +570,7 @@ year = {2023}
     editor = "Carpuat, Marine  and
       de Marneffe, Marie-Catherine  and
       Meza Ruiz, Ivan Vladimir",
-    booktitle = "Proceedings of the 2022 Conference of the North American Chapter of the Association for Computational Linguistics: Human Language Technologies",
+    booktitle = "Proceedings of the 2022 Conference of the {N}orth {A}merican Chapter of the Association for Computational Linguistics: Human Language Technologies",
     month = jul,
     year = "2022",
     address = "Seattle, United States",


### PR DESCRIPTION
"north american" -> "North American"