### PR TITLE
Remove redundant condition in evaluate method

### DIFF
--- a/langfair/metrics/stereotype/stereotype.py
+++ b/langfair/metrics/stereotype/stereotype.py
@@ -86,20 +86,12 @@ class StereotypeMetrics:
         metric_values = {}
         for metric in self.metrics:
             if metric.name in ["Stereotype Classifier"]:
-                if return_data:
-                    tmp_value = metric.evaluate(
-                        responses=responses,
-                        prompts=prompts,
-                        return_data=return_data,
-                        categories=categories,
-                    )
-                else:
-                    tmp_value = metric.evaluate(
-                        responses=responses,
-                        prompts=prompts,
-                        return_data=return_data,
-                        categories=categories,
-                    )
+                tmp_value = metric.evaluate(
+                    responses=responses,
+                    prompts=prompts,
+                    return_data=return_data,
+                    categories=categories,
+                )
                 metric_values.update(tmp_value["metrics"])
             else:
                 metric_values[metric.name] = metric.evaluate(responses=responses)


### PR DESCRIPTION
## Description
This PR simplifies the evaluation of stereotype metrics by removing an unnecessary conditional check for return_data in the evaluate method of the StereotypeMetrics class. The metric.evaluate method is now called only once, improving code clarity and maintainability.

## Contributor License Agreement
- [x] confirm you have signed the [LangFair CLA](https://forms.office.com/pages/responsepage.aspx?id=uGG7-v46dU65NKR_eCuM1xbiih2MIwxBuRvO0D_wqVFUMlFIVFdYVFozN1BJVjVBRUdMUUY5UU9QRS4u&route=shorturl)

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
- [x] no documentation changes needed
- [ ] README updated
- [ ] API docs added or updated
- [ ] example notebook added or updated
