### PR TITLE
Enhance substitution logic and update race word lists

### DIFF
--- a/langfair/constants/word_lists.py
+++ b/langfair/constants/word_lists.py
@@ -140,6 +140,7 @@ GENDER_TO_WORD_LISTS: Dict[str, List[str]] = {
 # For race, string search is done
 RACE_WORDS_NOT_REQUIRING_CONTEXT: List[str] = [
     "caucasian",
+    "asian-american",
     "african american",
     "african-american",
     "native american",
@@ -150,6 +151,8 @@ RACE_WORDS_NOT_REQUIRING_CONTEXT: List[str] = [
     "hispanics",
     "latinos",
     "latinas",
+    "latino",
+    "latina",
     "whites",
     "blacks",
     "indians",
@@ -164,8 +167,6 @@ RACE_WORDS_REQUIRING_CONTEXT: List[str] = [
     "white",
     "asian",
     "indian",
-    "latino",
-    "latina",
 ]
 
 PERSON_WORDS = [

--- a/langfair/generator/counterfactual.py
+++ b/langfair/generator/counterfactual.py
@@ -578,7 +578,7 @@ class CounterfactualGenerator(ResponseGenerator):
         Creates counterfactual variations based on a dictionary of reference lists.
         """
         ref_dict = {key: [t.lower() for t in val] for key, val in ref_dict.items()}
-        lower_tokens = word_tokenize(text)
+        lower_tokens = word_tokenize(text.lower())
 
         ref_values = {
             val: idx for key in ref_dict for idx, val in enumerate(ref_dict[key])

--- a/tests/test_counterfactualgenerator.py
+++ b/tests/test_counterfactualgenerator.py
@@ -23,10 +23,10 @@ async def test_counterfactual(monkeypatch):
     # TODO: Tests to check if `parse_texts` method works for all words in gender/race word list.
     # TODO: Add tests for `estimate_token_cost` method (first need to fix the bug)
     MOCKED_PROMPTS = [
-        "Prompt 1: male person",
-        "Prompt 2: female person",
-        "Prompt 3: white person",
-        "Prompt 4: black person",
+        "prompt 1: male person",
+        "prompt 2: female person",
+        "prompt 3: white person",
+        "prompt 4: black person",
     ]
     MOCKED_RACE_PROMPTS = {
         "white_prompt": ["prompt 3: white person", "prompt 4: white person"],
@@ -34,13 +34,13 @@ async def test_counterfactual(monkeypatch):
         "hispanic_prompt": ["prompt 3: hispanic person", "prompt 4: hispanic person"],
         "asian_prompt": ["prompt 3: asian person", "prompt 4: asian person"],
         "attribute_words": [["white person"], ["black person"]],
-        "original_prompt": ["Prompt 3: white person", "Prompt 4: black person"],
+        "original_prompt": ["prompt 3: white person", "prompt 4: black person"],
     }
     MOCKED_GENDER_PROMPTS = {
-        "male_prompt": ["Prompt 1: male person", "Prompt 2: male person"],
-        "female_prompt": ["Prompt 1: female person", "Prompt 2: female person"],
+        "male_prompt": ["prompt 1: male person", "prompt 2: male person"],
+        "female_prompt": ["prompt 1: female person", "prompt 2: female person"],
         "attribute_words": [["male"], ["female"]],
-        "original_prompt": ["Prompt 1: male person", "Prompt 2: female person"],
+        "original_prompt": ["prompt 1: male person", "prompt 2: female person"],
     }
     # MOCKED_CF_PROMPTS = list(MOCKED_RACE_PROMPTS.values()) + list(
     #     MOCKED_GENDER_PROMPTS.values()


### PR DESCRIPTION
## Description
- Added 'text.lower()' to '_sub_from_dict()' in counterfactual.py to ensure case-insensitive substitutions.
- Updated race word lists:
  - Moved 'latino' and 'latina' from RACE_WORDS_REQUIRING_CONTEXT to RACE_WORDS_NOT_REQUIRING_CONTEXT
  - Added 'asian-american' to RACE_WORDS_NOT_REQUIRING_CONTEXT

## Contributor License Agreement
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ X] confirm you have signed the [LangFair CLA](https://forms.office.com/pages/responsepage.aspx?id=uGG7-v46dU65NKR_eCuM1xbiih2MIwxBuRvO0D_wqVFUMlFIVFdYVFozN1BJVjVBRUdMUUY5UU9QRS4u&route=shorturl)

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no documentation changes needed
- [ ] README updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If applicable, please add screenshots. -->