### PR TITLE
Enable religion attribute for CounterfactualGenerator

### DIFF
--- a/langfair/constants/word_lists.py
+++ b/langfair/constants/word_lists.py
@@ -944,3 +944,19 @@ PROFESSION_LIST: List[str] = [
     "wrestler",
     "writer",
 ]
+
+RELIGION_NOUN_MAPPING = {
+    "christianity": ["islam", "hinduism", "judaism", "buddhism"],
+    "islam": ["christianity", "hinduism", "judaism", "buddhism"],
+    "hinduism": ["christianity", "islam", "judaism", "buddhism"],
+    "judaism": ["christianity", "islam", "hinduism", "buddhism"],
+    "buddhism": ["christianity", "islam", "hinduism", "judaism"],
+}
+
+RELIGION_ADJECTIVE_MAPPING = {
+    "christian": ["muslim", "hindu", "jewish", "buddhist"],
+    "muslim": ["christian", "hindu", "jewish", "buddhist"],
+    "hindu": ["christian", "muslim", "jewish", "buddhist"],
+    "jewish": ["christian", "muslim", "hindu", "buddhist"],
+    "buddhist": ["christian", "muslim", "hindu", "jewish"],
+}

--- a/tests/test_counterfactualgenerator.py
+++ b/tests/test_counterfactualgenerator.py
@@ -23,10 +23,10 @@ async def test_counterfactual(monkeypatch):
     # TODO: Tests to check if `parse_texts` method works for all words in gender/race word list.
     # TODO: Add tests for `estimate_token_cost` method (first need to fix the bug)
     MOCKED_PROMPTS = [
-        "Prompt 1: male person",
-        "Prompt 2: female person",
-        "Prompt 3: white person",
-        "Prompt 4: black person",
+        "prompt 1: male person",
+        "prompt 2: female person",
+        "prompt 3: white person",
+        "prompt 4: black person",
     ]
     MOCKED_RACE_PROMPTS = {
         "white_prompt": ["prompt 3: white person", "prompt 4: white person"],
@@ -34,13 +34,13 @@ async def test_counterfactual(monkeypatch):
         "hispanic_prompt": ["prompt 3: hispanic person", "prompt 4: hispanic person"],
         "asian_prompt": ["prompt 3: asian person", "prompt 4: asian person"],
         "attribute_words": [["white person"], ["black person"]],
-        "original_prompt": ["Prompt 3: white person", "Prompt 4: black person"],
+        "original_prompt": ["prompt 3: white person", "prompt 4: black person"],
     }
     MOCKED_GENDER_PROMPTS = {
-        "male_prompt": ["Prompt 1: male person", "Prompt 2: male person"],
-        "female_prompt": ["Prompt 1: female person", "Prompt 2: female person"],
+        "male_prompt": ["prompt 1: male person", "prompt 2: male person"],
+        "female_prompt": ["prompt 1: female person", "prompt 2: female person"],
         "attribute_words": [["male"], ["female"]],
-        "original_prompt": ["Prompt 1: male person", "Prompt 2: female person"],
+        "original_prompt": ["prompt 1: male person", "prompt 2: female person"],
     }
     # MOCKED_CF_PROMPTS = list(MOCKED_RACE_PROMPTS.values()) + list(
     #     MOCKED_GENDER_PROMPTS.values()


### PR DESCRIPTION
## Description
<!---- This PR introduces support for the religion attribute in the CounterfactualGenerator class. 
- Added handling for both adjective and noun forms (e.g., "Muslim", "Islam")
- Ensured mutual exclusivity: adjective-only prompts don't produce noun substitutions and vice versa
- Updated word_lists.py and counterfactual.py accordingly.  --->


## Contributor License Agreement
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ X ] confirm you have signed the [LangFair CLA](https://forms.office.com/pages/responsepage.aspx?id=uGG7-v46dU65NKR_eCuM1xbiih2MIwxBuRvO0D_wqVFUMlFIVFdYVFozN1BJVjVBRUdMUUY5UU9QRS4u&route=shorturl)

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no documentation changes needed
- [ ] README updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If applicable, please add screenshots. -->