### PR TITLE
fix: add ci ignores to optimize PR feedback

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,13 @@ name: CI
 on:
   push:
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - security-insights.yml
+      - .github/ISSUE_TEMPLATE/**
+      - assets/**
+      - examples/**
+      - plans/**
 
 jobs:
   run-tests:


### PR DESCRIPTION
## Description

PRs that change docs, data or config unrelated to the projects source and tests and CI config do not need to spawn a massive matrix of tests across various OSes.
    
This change adds the relevant CI configuration to ignore changes it need not test.

## Contributor License Agreement
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [X] confirm you have signed the [LangFair CLA](https://forms.office.com/pages/responsepage.aspx?id=uGG7-v46dU65NKR_eCuM1xbiih2MIwxBuRvO0D_wqVFUMlFIVFdYVFozN1BJVjVBRUdMUUY5UU9QRS4u&route=shorturl)

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [X] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [X] no documentation changes needed
- [ ] README updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If applicable, please add screenshots. -->
N/A