### PR TITLE
fix: update jupyter-core to v5.8.1 for CVE fix

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2028,15 +2028,15 @@ test = ["coverage", "ipykernel (>=6.14)", "mypy", "paramiko", "pre-commit", "pyt
 
 [[package]]
 name = "jupyter-core"
-version = "5.7.2"
+version = "5.8.1"
 description = "Jupyter core package. A base package on which Jupyter projects rely."
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 markers = "python_version >= \"3.12\" or python_version <= \"3.11\""
 files = [
-    {file = "jupyter_core-5.7.2-py3-none-any.whl", hash = "sha256:4f7315d2f6b4bcf2e3e7cb6e46772eba760ae459cd1f59d29eb57b0a01bd7409"},
-    {file = "jupyter_core-5.7.2.tar.gz", hash = "sha256:aa5f8d32bbf6b431ac830496da7392035d6f61b4f54872f15c4bd2a9c3f536d9"},
+    {file = "jupyter_core-5.8.1-py3-none-any.whl", hash = "sha256:c28d268fc90fb53f1338ded2eb410704c5449a358406e8a948b75706e24863d0"},
+    {file = "jupyter_core-5.8.1.tar.gz", hash = "sha256:0a5f9706f70e64786b75acba995988915ebd4601c8a52e534a40b51c95f59941"},
 ]
 
 [package.dependencies]
@@ -2045,8 +2045,8 @@ pywin32 = {version = ">=300", markers = "sys_platform == \"win32\" and platform_
 traitlets = ">=5.3"
 
 [package.extras]
-docs = ["myst-parser", "pydata-sphinx-theme", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling", "traitlets"]
-test = ["ipykernel", "pre-commit", "pytest (<8)", "pytest-cov", "pytest-timeout"]
+docs = ["intersphinx-registry", "myst-parser", "pydata-sphinx-theme", "sphinx-autodoc-typehints", "sphinxcontrib-spelling", "traitlets"]
+test = ["ipykernel", "pre-commit", "pytest (<9)", "pytest-cov", "pytest-timeout"]
 
 [[package]]
 name = "jupyterlab-widgets"
@@ -6063,4 +6063,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.13"
-content-hash = "2fd7429cc3d77f4fb7b4aef58e254e87d9688c6b6ae3dac72483a8febc6294b2"
+content-hash = "9c6a5b2d3b156301e385026dacfd7e54980c834e686f25216d3d0113150ee3fc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ ipykernel = "^6.29.5"
 ipywidgets = "^8.1.5"
 python-dotenv = "^1.0.1"
 bandit = "^1.8.6"
+jupyter-core = ">=5.8.1"
 
 [tool.poetry.group.docs.dependencies]
 sphinx = "7.3.7"


### PR DESCRIPTION
## Description
This PR updates the development dependency `jupyter-core` to `v5.8.1`

This dependency update of the dev dependencies is motivated by https://avd.aquasec.com/nvd/2025/cve-2025-30167/ which was discovered when running a Trivy scan against the `develop` branch of the project

The scan was invoked with: trivy fs --severity HIGH,CRITICAL --scanners vuln --include-dev-deps .

The only vuln in the scan report is the CVE linked above and the issue only impacts Windows users of `jupyter-core`

## Contributor License Agreement
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [X] confirm you have signed the [LangFair CLA](https://forms.office.com/pages/responsepage.aspx?id=uGG7-v46dU65NKR_eCuM1xbiih2MIwxBuRvO0D_wqVFUMlFIVFdYVFozN1BJVjVBRUdMUUY5UU9QRS4u&route=shorturl)

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [X] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [X] no documentation changes needed
- [ ] README updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If applicable, please add screenshots. -->