### PR TITLE
fix: rm snyk temporarily due to fork secret access issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,10 +76,10 @@ jobs:
         uses: snyk/actions/setup@86b1cee1b8e110a78d528b3e1328a80e218111d2
         with:
           snyk-version: v1.1298.3
-      - name: Run snyk test
-        run: snyk test --file=poetry.lock --package-manager=pip --fail-on=upgradable
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      # - name: Run snyk test
+      #   run: snyk test --file=poetry.lock --package-manager=pip --fail-on=upgradable
+      #   env:
+      #     SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   semgrep:
     name: semgrep/ci


### PR DESCRIPTION
## Description

Commenting out `snyk test` invocation from the CI workflow as when PRs are submitted by forked repositories, they cannot access the upstream repositories secrets and therefore the `snyk test` command fails due to missing auth credentials.

## Contributor License Agreement
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [X] confirm you have signed the [LangFair CLA](https://forms.office.com/pages/responsepage.aspx?id=uGG7-v46dU65NKR_eCuM1xbiih2MIwxBuRvO0D_wqVFUMlFIVFdYVFozN1BJVjVBRUdMUUY5UU9QRS4u&route=shorturl)

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no documentation changes needed
- [ ] README updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If applicable, please add screenshots. -->